### PR TITLE
Add support for host field

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ In case you don't know how to retrieve the MAC address of the speaker:
  3. Select the speaker of which you need the address
  4. Write down the MAC address
 
+## Host
+The host is the mac address (without `:`) + 01
+for instance, host would be `4098ADA356C401` (MAC + 01)
 ## Configuration
 
-Create a [`~/.homebridge/config.json`](https://github.com/nfarina/homebridge/blob/master/config-sample.json) file (change `name` and `mac` as necessary):
+Create a [`~/.homebridge/config.json`](https://github.com/nfarina/homebridge/blob/master/config-sample.json) file (change `name`, `mac` and `host` as necessary):
 
 
 ```json
@@ -68,7 +71,8 @@ Create a [`~/.homebridge/config.json`](https://github.com/nfarina/homebridge/blo
     {
       "accessory": "UEBoomSpeaker",
       "name": "Bathroom Speaker",
-      "mac": "CA:38:93:3B:D8:5D"
+      "mac": "CA:38:93:3B:D8:5D",
+      "host": "4098ADA356C401"
     }
   ],
   "platforms": []

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function UEBoomSpeaker(log, config) {
   this.reverse = false;
   this.time = 1000;
   this.mac = config.mac;
+  this.host = config.host;
   this._service = new Service.Switch(this.name);
 
   this.cacheDirectory = HomebridgeAPI.user.persistPath();
@@ -51,7 +52,7 @@ UEBoomSpeaker.prototype._setOn = function(on, callback) {
   this.storage.setItemSync(this.name, on);
 
   if (on) {
-    const command = "gatttool -i hci0 -b " + this.mac + " --char-write-req -a 0x0003 -n 4098ADA356C401";
+    const command = "gatttool -i hci0 -b " + this.mac + " --char-write-req -a 0x0003 -n " + this.host;
     child = exec(command,
       function(error, stdout, stderr) {
         if (error !== null) {


### PR DESCRIPTION
This host field is necessary since the value of the gatttool command depends of which device UE BOOM was configured. In that case, is the MAC address of the device (in my case, my iPhone) + 01

I changed the readme as well.